### PR TITLE
Migrate  jcenter to mavenCentral

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext.kotlin_version = '1.7.10'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -17,7 +17,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
JCenter is being sunset and is readonly now https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter. Migrate plugins build.gradle configs from jcenter() to mavenCentral() maven repository.

### What does this change?

