### PR TITLE
Added namespace to android build.gradle file

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'jp.wasabeef.ua.client_hints'
     compileSdkVersion 33
 
     sourceSets {


### PR DESCRIPTION
Android is now requiring the namespace in order to build any application.

This PR fixes the following issue occurring while compiling:
```
* What went wrong:
A problem occurred configuring project ':ua_client_hints'.
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Specify a namespace in the module's build file. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.

     If you've specified the package attribute in the source AndroidManifest.xml, you can use the AGP Upgrade Assistant to migrate to the namespace value in the build file. Refer to https://d.android.com/r/tools/upgrade-assistant/agp-upgrade-assistant for general information about using the AGP Upgrade Assistant.
```

This is the Google's official documentation about namespace:
https://developer.android.com/build/publish-library/prep-lib-release#choose-namespace