### PR TITLE
fix(android): support AGP 9 built-in Kotlin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+**Bug fix**
+- Support AGP 9 built-in Kotlin while preserving compatibility with projects using the external Kotlin Gradle Plugin.
+
 ## 1.7.0
 
 **Feature**

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,8 +21,16 @@ rootProject.allprojects {
     }
 }
 
+// AGP 9 can run with or without built-in Kotlin, so inspect the consuming
+// app's explicit setting instead of inferring the mode from the AGP version.
+def builtInKotlinEnabled = (project.findProperty('android.builtInKotlin') ?: 'false')
+        .toString()
+        .toBoolean()
+
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+if (!builtInKotlinEnabled) {
+    apply plugin: 'kotlin-android'
+}
 
 android {
     namespace 'jp.wasabeef.ua.client_hints'
@@ -43,8 +51,10 @@ android {
         targetCompatibility JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = '17'
+    if (!builtInKotlinEnabled) {
+        kotlinOptions {
+            jvmTarget = '17'
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #168